### PR TITLE
Some fixes for SeqPrep filtering sub-wf

### DIFF
--- a/tools/Raw_reads/filter_paired_reads/filter_paired_reads.cwl
+++ b/tools/Raw_reads/filter_paired_reads/filter_paired_reads.cwl
@@ -25,7 +25,7 @@ inputs:
     inputBinding:
         prefix: -l
 
-baseCommand: [filter_paired_reads.sh]
+baseCommand: [filter_paired_reads_uncompressed.sh]
 
 outputs:
   forward_filtered:

--- a/tools/Raw_reads/filter_paired_reads/filter_paired_reads.cwl
+++ b/tools/Raw_reads/filter_paired_reads/filter_paired_reads.cwl
@@ -7,7 +7,7 @@ label: "remove reads from both files that are less than LEN"
 requirements:
   ResourceRequirement:
     coresMax: 1
-    ramMin: 200
+    ramMin: 5000
 
 inputs:
   forward:

--- a/tools/Raw_reads/filter_paired_reads/filter_paired_reads.sh
+++ b/tools/Raw_reads/filter_paired_reads/filter_paired_reads.sh
@@ -10,13 +10,13 @@ while getopts :f:r:l: option; do
 	esac
 done
 
-#gunzip -c ${FORWARD} > forward.fastq
-#gunzip -c ${REVERSE} > reverse.fastq
+gunzip -c ${FORWARD} > forward.fastq
+gunzip -c ${REVERSE} > reverse.fastq
 
-seqtk comp ${FORWARD} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_1
-seqtk comp ${REVERSE} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_2
+seqtk comp forward.fastq | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_1
+seqtk comp reverse.fastq | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_2
 
 comm -12 selected_1 selected_2 > common
 
-seqtk subseq ${FORWARD} common > forward_filt.fastq
-seqtk subseq ${REVERSE} common > reverse_filt.fastq
+seqtk subseq forward.fastq common > forward_filt.fastq
+seqtk subseq reverse.fastq common > reverse_filt.fastq

--- a/tools/Raw_reads/filter_paired_reads/filter_paired_reads.sh
+++ b/tools/Raw_reads/filter_paired_reads/filter_paired_reads.sh
@@ -10,13 +10,13 @@ while getopts :f:r:l: option; do
 	esac
 done
 
-gunzip -c ${FORWARD} > forward.fastq
-gunzip -c ${REVERSE} > reverse.fastq
+#gunzip -c ${FORWARD} > forward.fastq
+#gunzip -c ${REVERSE} > reverse.fastq
 
-seqtk comp forward.fastq | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_1
-seqtk comp reverse.fastq | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_2
+seqtk comp ${FORWARD} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_1
+seqtk comp ${REVERSE} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_2
 
 comm -12 selected_1 selected_2 > common
 
-seqtk subseq forward.fastq common > forward_filt.fastq
-seqtk subseq reverse.fastq common > reverse_filt.fastq
+seqtk subseq ${FORWARD} common > forward_filt.fastq
+seqtk subseq ${REVERSE} common > reverse_filt.fastq

--- a/tools/Raw_reads/filter_paired_reads/filter_paired_reads_uncompressed.sh
+++ b/tools/Raw_reads/filter_paired_reads/filter_paired_reads_uncompressed.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+while getopts :f:r:l: option; do
+	case "${option}" in
+		f) FORWARD=${OPTARG};;
+		r) REVERSE=${OPTARG};;
+		l) LEN=${OPTARG};;
+	esac
+done
+
+seqtk comp ${FORWARD} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_1
+seqtk comp ${REVERSE} | awk -v l="${LEN}" '{ if ($2 >= l) { print} }' | cut -f1 | sort > selected_2
+
+comm -12 selected_1 selected_2 > common
+
+seqtk subseq ${FORWARD} common > forward_filt.fastq
+seqtk subseq ${REVERSE} common > reverse_filt.fastq

--- a/utils/multiple-gunzip.cwl
+++ b/utils/multiple-gunzip.cwl
@@ -46,7 +46,7 @@ inputs:
 baseCommand: [ gunzip, -c ]
 
 outputs:
-  unzipped_merged_reads:
+  unzipped_file:
     type: stdout
     # <<doesn't support by cwltoil>> format: $(inputs.target_reads.format)
 

--- a/utils/multiple-gunzip.cwl
+++ b/utils/multiple-gunzip.cwl
@@ -48,7 +48,7 @@ baseCommand: [ gunzip, -c ]
 outputs:
   unzipped_file:
     type: stdout
-    # <<doesn't support by cwltoil>> format: $(inputs.target_reads.format)
+    format: $(inputs.target_reads.format)
 
 stdout: ${ var ext = "";
        if (inputs.assembly) { ext = inputs.target_reads.nameroot.split('.')[0] + '_FASTA.unfiltered'; }

--- a/workflows/assembly-wf--v.5-cond.cwl
+++ b/workflows/assembly-wf--v.5-cond.cwl
@@ -92,7 +92,7 @@ outputs:
     outputSource: before-qc/qc-statistics_folder
 
 # << root folder >>
-  compressed_files:                                          # [5] fasta, cmsearch, ncRNA, deoverlapped
+  compressed_files:                                          # [2] cmsearch, deoverlapped
     type: File[]
     outputSource: after-qc/compressed_files
     pickValue: all_non_null

--- a/workflows/conditionals/amplicon/amplicon-1.cwl
+++ b/workflows/conditionals/amplicon/amplicon-1.cwl
@@ -69,6 +69,12 @@ steps:
       input_file: single_reads
     out: [ hashsum ]
 
+  count_submitted_reads:
+    run: ../../../utils/count_lines/count_lines.cwl
+    in:
+      sequences: overlap_reads/unzipped_single_reads
+      number: { default: 4 }
+    out: [ count ]
 
 # << SeqPrep (only for paired reads) + gunzip for paired and single>>
   overlap_reads:
@@ -80,13 +86,6 @@ steps:
       reverse_reads: reverse_reads
       paired_reads_length_filter: { default: 70 }
     out: [ unzipped_single_reads ]
-
-  count_submitted_reads:
-    run: ../../../utils/count_lines/count_lines.cwl
-    in:
-      sequences: overlap_reads/unzipped_single_reads
-      number: { default: 4 }
-    out: [ count ]
 
 # << Trim and Reformat >>
   trimming:

--- a/workflows/conditionals/amplicon/amplicon-1.cwl
+++ b/workflows/conditionals/amplicon/amplicon-1.cwl
@@ -69,13 +69,6 @@ steps:
       input_file: single_reads
     out: [ hashsum ]
 
-  count_submitted_reads:
-    run: ../../../utils/count_lines/count_lines.cwl
-    in:
-      sequences: overlap_reads/unzipped_single_reads
-      number: { default: 4 }
-    out: [ count ]
-
 # << SeqPrep (only for paired reads) + gunzip for paired and single>>
   overlap_reads:
     label: Paired-end overlapping reads are merged
@@ -85,14 +78,13 @@ steps:
       forward_reads: forward_reads
       reverse_reads: reverse_reads
       paired_reads_length_filter: { default: 70 }
-    out: [ unzipped_single_reads ]
+    out: [ unzipped_single_reads, count_forward_submitted_reads ]
 
 # << Trim and Reformat >>
   trimming:
     run: ../../subworkflows/trim_and_reformat_reads.cwl
     in:
       reads: overlap_reads/unzipped_single_reads
-      count: count_submitted_reads/count
     out: [ trimmed_and_reformatted_reads ]
 
 # << QC filtering >>
@@ -100,7 +92,7 @@ steps:
     run: ../../../tools/qc-filtering/qc-filtering.cwl
     in:
       seq_file: trimming/trimmed_and_reformatted_reads
-      submitted_seq_count: count_submitted_reads/count
+      submitted_seq_count: overlap_reads/count_forward_submitted_reads
       stats_file_name: {default: 'qc_summary'}
       min_length: qc_min_length
       input_file_format: { default: 'fasta' }

--- a/workflows/conditionals/amplicon/amplicon-1.cwl
+++ b/workflows/conditionals/amplicon/amplicon-1.cwl
@@ -78,7 +78,7 @@ steps:
       single_reads: single_reads
       forward_reads: forward_reads
       reverse_reads: reverse_reads
-      paired_reads_length_filter: { default: 100 }
+      paired_reads_length_filter: { default: 70 }
     out: [ unzipped_single_reads ]
 
   count_submitted_reads:

--- a/workflows/conditionals/assembly/assembly-1.cwl
+++ b/workflows/conditionals/assembly/assembly-1.cwl
@@ -58,13 +58,13 @@ steps:
     in:
       target_reads: contigs
       assembly: {default: true}
-    out: [unzipped_merged_reads]
+    out: [unzipped_file]
     run: ../../../utils/multiple-gunzip.cwl
 
 # << count reads pre QC >>
   count_reads:
     in:
-      sequences: unzip/unzipped_merged_reads
+      sequences: unzip/unzipped_file
       number: { default: 1 }
     out: [ count ]
     run: ../../../utils/count_fasta.cwl
@@ -72,7 +72,7 @@ steps:
 # <<clean fasta headers??>>
   clean_headers:
     in:
-      sequences: unzip/unzipped_merged_reads
+      sequences: unzip/unzipped_file
     out: [ sequences_with_cleaned_headers ]
     run: ../../../utils/clean_fasta_headers.cwl
     label: "removes spaces in some headers"

--- a/workflows/conditionals/raw-reads/raw-reads-1.cwl
+++ b/workflows/conditionals/raw-reads/raw-reads-1.cwl
@@ -81,14 +81,7 @@ steps:
       forward_reads: forward_reads
       reverse_reads: reverse_reads
       paired_reads_length_filter: { default: 70 }
-    out: [ unzipped_single_reads ]
-
-  count_submitted_reads:
-    run: ../../../utils/count_lines/count_lines.cwl
-    in:
-      sequences: overlap_reads/unzipped_single_reads
-      number: { default: 4 }
-    out: [ count ]
+    out: [ unzipped_single_reads, count_forward_submitted_reads ]
 
 # << Trim and Reformat >>
   trim_quality_control:
@@ -126,7 +119,7 @@ steps:
     run: ../../../tools/qc-filtering/qc-filtering.cwl
     in:
       seq_file: convert_trimmed_reads_to_fasta/fasta
-      submitted_seq_count: count_submitted_reads/count
+      submitted_seq_count: overlap_reads/count_forward_submitted_reads
       stats_file_name: {default: 'qc_summary'}
       min_length: qc_min_length
       input_file_format: { default: 'fasta' }

--- a/workflows/conditionals/raw-reads/raw-reads-1.cwl
+++ b/workflows/conditionals/raw-reads/raw-reads-1.cwl
@@ -80,7 +80,7 @@ steps:
       single_reads: single_reads
       forward_reads: forward_reads
       reverse_reads: reverse_reads
-      paired_reads_length_filter: { default: 100 }
+      paired_reads_length_filter: { default: 70 }
     out: [ unzipped_single_reads ]
 
   count_submitted_reads:

--- a/workflows/conditionals/raw-reads/raw-reads-2.cwl
+++ b/workflows/conditionals/raw-reads/raw-reads-2.cwl
@@ -222,7 +222,6 @@ steps:
     in:
       uncompressed_file:
         source:
-          - filtered_fasta                        # _FASTA
           - rna_prediction/ncRNA                        # cmsearch.all.deoverlapped
           - rna_prediction/cmsearch_result              # cmsearch.all
         linkMerge: merge_flattened

--- a/workflows/subworkflows/seqprep-subwf.cwl
+++ b/workflows/subworkflows/seqprep-subwf.cwl
@@ -25,9 +25,14 @@ outputs:
 
   count_forward_submitted_reads:
     type: int
-    outputSource: count_submitted_reads/count
+    outputSource:
+      - count_submitted_reads/count
+      - count_submitted_reads_single/count
+    pickValue: first_non_null
 
 steps:
+
+# ----- PAIRED-END PART -----
 
 # << unzipping paired reads >>
   unzip_forward_reads:
@@ -89,6 +94,8 @@ steps:
       reads: { default: true }
     out: [ unzipped_file ]
 
+# ----- SINGLE-END PART -----
+
 # << unzipping single reads >>
   unzip_single_reads:
     run: ../../utils/multiple-gunzip.cwl
@@ -97,6 +104,16 @@ steps:
       target_reads: single_reads
       reads: { default: true }
     out: [ unzipped_file ]
+
+  count_submitted_reads_single:
+    run: ../../utils/count_lines/count_lines.cwl
+    when: $(inputs.target_reads != undefined)
+    in:
+      target_reads: single_reads
+      sequences: unzip_single_reads/unzipped_file
+      number: { default: 4 }
+    out: [ count ]
+
 
 $namespaces:
  edam: http://edamontology.org/

--- a/workflows/subworkflows/seqprep-subwf.cwl
+++ b/workflows/subworkflows/seqprep-subwf.cwl
@@ -24,7 +24,7 @@ outputs:
     pickValue: first_non_null
 
   count_forward_submitted_reads:
-    type: File
+    type: int
     outputSource: count_submitted_reads/count
 
 steps:

--- a/workflows/subworkflows/seqprep-subwf.cwl
+++ b/workflows/subworkflows/seqprep-subwf.cwl
@@ -23,6 +23,10 @@ outputs:
       - unzip_single_reads/unzipped_file
     pickValue: first_non_null
 
+  count_forward_submitted_reads:
+    type: File
+    outputSource: count_submitted_reads/count
+
 steps:
 
 # << unzipping paired reads >>
@@ -44,14 +48,23 @@ steps:
       reads: { default: true }
     out: [ unzipped_file ]
 
+  count_submitted_reads:
+    run: ../../utils/count_lines/count_lines.cwl
+    when: $(inputs.single == undefined)
+    in:
+      single: single_reads
+      sequences: unzip_forward_reads/unzipped_file
+      number: { default: 4 }
+    out: [ count ]
+
 # filter paired-end reads (for single do nothing)
   filter_paired:
     run: ../../tools/Raw_reads/filter_paired_reads/filter_paired_reads.cwl
     when: $(inputs.single == undefined)
     in:
       single: single_reads
-      forward: forward_reads
-      reverse: reverse_reads
+      forward: unzip_forward_reads/unzipped_file
+      reverse: unzip_reverse_reads/unzipped_file
       len: paired_reads_length_filter
     out: [ forward_filtered, reverse_filtered ]  # unzipped
 

--- a/workflows/subworkflows/trim_and_reformat_reads.cwl
+++ b/workflows/subworkflows/trim_and_reformat_reads.cwl
@@ -11,7 +11,6 @@ requirements:
 
 inputs:
   reads: File
-  count: int
 
 outputs:
   trimmed_and_reformatted_reads:
@@ -23,13 +22,20 @@ outputs:
  
 steps:
 
+  count_overlapped_reads:
+    run: ../../utils/count_lines/count_lines.cwl
+    in:
+      sequences: reads
+      number: { default: 4 }
+    out: [ count ]
+
   # return empty_file == input_file if it is absolutely empty
   touch_empty_fasta:
     when: $(inputs.fastq_count == 0)
     run: ../../utils/touch_file.cwl
     in:
       filename: { default: 'empty.fasta' }
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [ created_file ]
 
   # << Chunk faa file >>
@@ -38,7 +44,7 @@ steps:
       seqs: reads
       chunk_size: { default: 1000000 }
       file_format: { default: 'fastq' }
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [ chunks ]
     run: ../../tools/chunks/protein_chunker.cwl
 
@@ -57,7 +63,7 @@ steps:
       end_mode: { default: SE }
       minlen: { default: 100 }
       slidingwindow: { default: '4:15' }
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [reads1_trimmed]
 
   combine_trimmed:
@@ -68,7 +74,7 @@ steps:
         source: reads
         valueFrom: $(self.nameroot)
       postfix: { default: '.trimmed' }
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [result]
     run: ../../utils/concatenate.cwl
 
@@ -77,7 +83,7 @@ steps:
     run: ../../utils/fastq_to_fasta/fastq_to_fasta.cwl
     in:
       fastq: combine_trimmed/result
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [ fasta ]
 
   clean_fasta_headers:
@@ -85,7 +91,7 @@ steps:
     run: ../../utils/clean_fasta_headers.cwl
     in:
       sequences: convert_trimmed_reads_to_fasta/fasta
-      fastq_count: count
+      fastq_count: count_overlapped_reads/count
     out: [ sequences_with_cleaned_headers ]
 
 $namespaces:

--- a/workflows/subworkflows/trim_and_reformat_reads.cwl
+++ b/workflows/subworkflows/trim_and_reformat_reads.cwl
@@ -40,6 +40,7 @@ steps:
 
   # << Chunk faa file >>
   split_seqs:
+    when: $(inputs.fastq_count != 0)
     in:
       seqs: reads
       chunk_size: { default: 1000000 }


### PR DESCRIPTION
- changed filtering before seqprep (from 100bp to 70bp)
- fixed submitted_reads field in qc_summary
- removed *_FASTQ.fasta.gz from output of raw-reads pipeline