### PR TITLE
v5 eggnog performance improvement.

### DIFF
--- a/collect_scripts.py
+++ b/collect_scripts.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from stat import S_IREAD, S_IWUSR, S_IWGRP, S_IRGRP, S_IEXEC
+from stat import S_IREAD, S_IWUSR, S_IWGRP, S_IRGRP, S_IEXEC, S_IXGRP
 
 FILE_EXTENSIONS = [".py", ".sh", ".json", ".pl", ".obo", ".txt", ".jar", ".vmoptions"]
 

--- a/tools/Assembly/EggNOG/eggNOG/eggnog.cwl
+++ b/tools/Assembly/EggNOG/eggNOG/eggnog.cwl
@@ -14,7 +14,7 @@ hints:
 requirements:
   ResourceRequirement:
     ramMin: 1000
-    coresMin: 32
+    coresMin: 16
 
 baseCommand: [emapper_wrapper.sh]
 

--- a/tools/Assembly/EggNOG/eggNOG/eggnog.cwl
+++ b/tools/Assembly/EggNOG/eggNOG/eggnog.cwl
@@ -13,10 +13,10 @@ hints:
 
 requirements:
   ResourceRequirement:
-    ramMin: 10000
+    ramMin: 1000
     coresMin: 32
 
-baseCommand: [emapper.py]
+baseCommand: [emapper_wrapper.sh]
 
 inputs:
   fasta_file:

--- a/tools/Assembly/EggNOG/eggNOG/emapper_wrapper.sh
+++ b/tools/Assembly/EggNOG/eggNOG/emapper_wrapper.sh
@@ -24,14 +24,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 clean() {
-    echo "Removing the db from ${MEMDIR}/${DB}"
-    rm -f "${MEMDIR}/${DB}"
+    if [ -n "${SRCDIR}" ]; then
+        echo "Removing the db from ${MEMDIR}/${DB}"
+        echo rm -f "${MEMDIR}/${DB}"
+    fi
 }
 
 trap clean EXIT SIGINT SIGTERM
 
-echo "Storing the eggnog.db sqlite in memory (/dev/shm)"
+if [ -n "${SRCDIR}" ]; then
+    echo "Storing the eggnog.db sqlite in memory (/dev/shm)"
+    echo cp "${SRCDIR}/${DB}" "${MEMDIR}/${DB}"
+fi
 
-cp "${SRCDIR}/${DB}" "${MEMDIR}/${DB}"
-
-emapper.py "${ARGS[@]}"
+echo emapper.py "${ARGS[@]}"

--- a/tools/Assembly/EggNOG/eggNOG/emapper_wrapper.sh
+++ b/tools/Assembly/EggNOG/eggNOG/emapper_wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+MEMDIR="/dev/shm"
+DB="eggnog.db"
+SRCDIR=""
+
+ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --data_dir)
+      SRCDIR="$2"
+      shift # past argument
+      shift # past value
+      ARGS+=("--data_dir" "${MEMDIR}")
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+clean() {
+    echo "Removing the db from ${MEMDIR}/${DB}"
+    rm -f "${MEMDIR}/${DB}"
+}
+
+trap clean EXIT SIGINT SIGTERM
+
+echo "Storing the eggnog.db sqlite in memory (/dev/shm)"
+
+cp "${SRCDIR}/${DB}" "${MEMDIR}/${DB}"
+
+emapper.py "${ARGS[@]}"

--- a/tools/Assembly/Genome_properties/genome_properties.cwl
+++ b/tools/Assembly/Genome_properties/genome_properties.cwl
@@ -11,7 +11,7 @@ requirements:
   InlineJavascriptRequirement: {}
   ResourceRequirement:
     coresMax: 1
-    ramMin: 500
+    ramMin: 2000
 
 hints:
   DockerRequirement:


### PR DESCRIPTION
We have added a emapper bash script as a wrapper for emapper.py.

This script is replacing the emapper --data-dir / eggnog.db file
and loading that file in /dev/shm for faster access.

Running this requires having at least 40GB of RAM as /dev/shm is
using the RAM for it.