### PR TITLE
for CWL v1.2, use final version number, not -devN

### DIFF
--- a/tools/Assembly/antismash/chunking_antismash_with_conditionals/antismash_chunking_subwf.cwl
+++ b/tools/Assembly/antismash/chunking_antismash_with_conditionals/antismash_chunking_subwf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 label: "WF leaves sequences that length is more than 1000bp, run antismash + gene clusters post-processing, GFF generation"
 

--- a/tools/Assembly/antismash/chunking_antismash_with_conditionals/antismash_subwf.cwl
+++ b/tools/Assembly/antismash/chunking_antismash_with_conditionals/antismash_subwf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 label: "antismash + change locus tag "
 

--- a/tools/Assembly/antismash/chunking_antismash_with_conditionals/filtering_fasta_for_antismash.cwl
+++ b/tools/Assembly/antismash/chunking_antismash_with_conditionals/filtering_fasta_for_antismash.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 label: "WF leaves sequences that length is more than 1000bp, run antismash + gene clusters post-processing, GFF generation"
 

--- a/tools/Assembly/antismash/chunking_antismash_with_conditionals/no_antismash_subwf.cwl
+++ b/tools/Assembly/antismash/chunking_antismash_with_conditionals/no_antismash_subwf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 label: "If filtered file is empty -> return file-flag no_antismash"
 

--- a/tools/Assembly/antismash/chunking_antismash_with_conditionals/wf_antismash.cwl
+++ b/tools/Assembly/antismash/chunking_antismash_with_conditionals/wf_antismash.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 label: "WF leaves sequences that length is more than 1000bp, run antismash + gene clusters post-processing, GFF generation"
 

--- a/workflows/amplicon-wf--v.5-cond.cwl
+++ b/workflows/amplicon-wf--v.5-cond.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/assembly-wf--v.5-cond.cwl
+++ b/workflows/assembly-wf--v.5-cond.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   - class: ResourceRequirement

--- a/workflows/conditionals/amplicon/amplicon-1.cwl
+++ b/workflows/conditionals/amplicon/amplicon-1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/conditionals/amplicon/amplicon-2.cwl
+++ b/workflows/conditionals/amplicon/amplicon-2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/conditionals/assembly/assembly-2.cwl
+++ b/workflows/conditionals/assembly/assembly-2.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 requirements:
 #  - class: SchemaDefRequirement

--- a/workflows/conditionals/raw-reads/raw-reads-1.cwl
+++ b/workflows/conditionals/raw-reads/raw-reads-1.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/conditionals/raw-reads/raw-reads-2.cwl
+++ b/workflows/conditionals/raw-reads/raw-reads-2.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/raw-reads-wf--v.5-cond.cwl
+++ b/workflows/raw-reads-wf--v.5-cond.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/subworkflows/amplicon/ITS-wf.cwl
+++ b/workflows/subworkflows/amplicon/ITS-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 class: Workflow
 label: "ITS SubWorkflow"
 

--- a/workflows/subworkflows/amplicon/trim_and_reformat_reads.cwl
+++ b/workflows/subworkflows/amplicon/trim_and_reformat_reads.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 class: Workflow
 label: Trim and reformat reads (single and paired end version)
 

--- a/workflows/subworkflows/amplicon/trimming-not-empty-subwf.cwl
+++ b/workflows/subworkflows/amplicon/trimming-not-empty-subwf.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 class: Workflow
 label: Trim and reformat reads (single and paired end version)
 

--- a/workflows/subworkflows/assembly/func_ann_and_post_processing-subwf.cwl
+++ b/workflows/subworkflows/assembly/func_ann_and_post_processing-subwf.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 requirements:
   - class: ResourceRequirement

--- a/workflows/subworkflows/classify-otu-visualise.cwl
+++ b/workflows/subworkflows/classify-otu-visualise.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 class: Workflow
 label: "Run taxonomic classification, create OTU table and krona visualisation"
 

--- a/workflows/subworkflows/cmsearch-condition.cwl
+++ b/workflows/subworkflows/cmsearch-condition.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 class: Workflow
 $namespaces:
   edam: 'http://edamontology.org/'

--- a/workflows/subworkflows/final_chunking.cwl
+++ b/workflows/subworkflows/final_chunking.cwl
@@ -1,5 +1,5 @@
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 $namespaces:
   edam: 'http://edamontology.org/'

--- a/workflows/subworkflows/raw_reads/func_ann_and_post_proccessing-subwf.cwl
+++ b/workflows/subworkflows/raw_reads/func_ann_and_post_proccessing-subwf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev4
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/subworkflows/rna_prediction-sub-wf.cwl
+++ b/workflows/subworkflows/rna_prediction-sub-wf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}

--- a/workflows/subworkflows/seqprep-subwf.cwl
+++ b/workflows/subworkflows/seqprep-subwf.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-cwlVersion: v1.2.0-dev2
+cwlVersion: v1.2
 
 requirements:
   SubworkflowFeatureRequirement: {}


### PR DESCRIPTION
The only change from CWL `v1.2.0-dev2` to `v1.2` was the `pickValue` option `only_non_null` renamed to `the_only_non_null`

But that `pickValue` option was not used here, so no other changes are needed.